### PR TITLE
Add test for signer param to Ed25519Signature2020 constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @digitalbazaar/ed25519-signature-2020 Changelog
 
+## 2.0.0 -
+
+### Changed
+- **BREAKING**: Update to use `jsonld-signatures` v9.0 (removes 
+  `verificationMethod` suite constructor param, makes key and signer validation
+  stricter).
+- Fix initializing signer and verifier object by passing it to superclass.
+
 ## 1.0.0 - 2021-03-19
 
 ### Added

--- a/lib/Ed25519Signature2020.js
+++ b/lib/Ed25519Signature2020.js
@@ -14,13 +14,24 @@ const SUITE_CONTEXT = 'https://w3id.org/security/suites/ed25519-2020/v1';
 export class Ed25519Signature2020 extends LinkedDataSignature {
   /**
    * @param {object} options - Options hashmap.
-   * @param {string} [options.verificationMethod] - A key id URL to the paired
-   *   public key.
-   * @param {Function} [options.signer] - Signer function.
+   *
+   * Either a `key` OR at least one of `signer`/`verifier` is required:
+   *
+   * @param {object} [options.key] - An optional key object (containing an
+   *   `id` property, and either `signer` or `verifier`, depending on the
+   *   intended operation. Useful for when the application is managing keys
+   *   itself (when using a KMS, you never have access to the private key,
+   *   and so should use the `signer` param instead).
+   * @param {Function} [options.signer] - Signer function that returns an
+   *   object with an async sign() method. This is useful when interfacing
+   *   with a KMS (since you don't get access to the private key and its
+   *   `signer()`, the KMS client gives you only the signer function to use).
+   * @param {Function} [options.verifier] - Verifier function that returns
+   *   an object with an async `verify()` method. Useful when working with a
+   *   KMS-provided verifier function.
    *
    * Advanced optional parameters and overrides:
    *
-   * @param {object} [options.key] - An optional crypto-ld KeyPair.
    * @param {object} [options.proof] - A JSON-LD document with options to use
    *   for the `proof` node (e.g. any other custom fields can be provided here
    *   using a context different from security-v2).
@@ -29,28 +40,13 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
    *   canonize algorithm.
    */
   constructor({
-    signer, verificationMethod, key, proof, date, useNativeCanonize
+    key, signer, verifier, proof, date, useNativeCanonize
   } = {}) {
     super({
-      // type: 'https://w3id.org/security#Ed25519Signature2020',
-      type: 'Ed25519Signature2020',
-      alg: 'EdDSA', LDKeyClass: Ed25519VerificationKey2020, verificationMethod,
-      signer, key, proof, date, useNativeCanonize
+      type: 'Ed25519Signature2020', LDKeyClass: Ed25519VerificationKey2020,
+      key, signer, verifier, proof, date, useNativeCanonize
     });
     this.requiredKeyType = 'Ed25519VerificationKey2020';
-
-    if(key) {
-      if(verificationMethod === undefined) {
-        this.verificationMethod = key.id;
-      }
-      this.key = key;
-      if(typeof key.signer === 'function') {
-        this.signer = key.signer();
-      }
-      if(typeof key.verifier === 'function') {
-        this.verifier = key.verifier();
-      }
-    }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "base58-universal": "^1.0.0",
     "esm": "^3.2.25",
     "jsonld": "^5.0.0",
-    "jsonld-signatures": "digitalbazaar/jsonld-signatures#set-ver-method"
+    "jsonld-signatures": "^9.0.0"
   },
   "devDependencies": {
     "@transmute/jsonld-document-loader": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "base58-universal": "^1.0.0",
     "esm": "^3.2.25",
     "jsonld": "^5.0.0",
-    "jsonld-signatures": "digitalbazaar/jsonld-signatures#fix-136"
+    "jsonld-signatures": "digitalbazaar/jsonld-signatures#set-ver-method"
   },
   "devDependencies": {
     "@transmute/jsonld-document-loader": "^0.2.0",
@@ -52,7 +52,7 @@
   "scripts": {
     "test": "npm run lint && npm run test-node && npm run test-karma",
     "test-karma": "karma start karma.conf.js",
-    "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} test/*.spec.js",
+    "test-node": "cross-env NODE_ENV=test mocha -b -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} test/*.spec.js",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test-node",
     "coverage-report": "nyc report",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "base58-universal": "^1.0.0",
     "esm": "^3.2.25",
     "jsonld": "^5.0.0",
-    "jsonld-signatures": "^8.0.2"
+    "jsonld-signatures": "digitalbazaar/jsonld-signatures#fix-136"
   },
   "devDependencies": {
     "@transmute/jsonld-document-loader": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "test": "npm run lint && npm run test-node && npm run test-karma",
     "test-karma": "karma start karma.conf.js",
-    "test-node": "cross-env NODE_ENV=test mocha -b -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} test/*.spec.js",
+    "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} test/*.spec.js",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test-node",
     "coverage-report": "nyc report",

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -91,9 +91,9 @@ describe('Ed25519Signature2020', () => {
     it('should throw error if "signer" is not specified', async () => {
       const unsignedCredential = {...credential};
       let signedCredential;
+      const suite = new Ed25519Signature2020();
       let err;
       try {
-        const suite = new Ed25519Signature2020();
         signedCredential = await jsigs.sign(unsignedCredential, {
           suite,
           purpose: new AssertionProofPurpose(),
@@ -104,8 +104,7 @@ describe('Ed25519Signature2020', () => {
       }
       expect(signedCredential).to.equal(undefined);
       expect(err.name).to.equal('Error');
-      expect(err.message).to
-        .equal('A signer API has not been specified.');
+      expect(err.message).to.equal('A signer API has not been specified.');
     });
   });
 

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -69,6 +69,25 @@ describe('Ed25519Signature2020', () => {
         .equal('zfMw453FJfB7c6Cx4Lo9dho8ePVnZrSwLeFAhUFPZXaS3pe1' +
           'nS7v3PXFNkxvK515eNweAEiCbtceWGYQyLjtD2uB');
     });
+    it('signs a document given a signer and verificationMethod', async () => {
+      const unsignedCredential = {...credential};
+      const keyPair = await Ed25519VerificationKey2020.from({...mockKeyPair});
+      const signer = keyPair.signer();
+      const verificationMethod = keyPair.id;
+      const suite = new Ed25519Signature2020({signer, verificationMethod});
+      suite.date = '2010-01-01T19:23:24Z';
+
+      const signedCredential = await jsigs.sign(unsignedCredential, {
+        suite,
+        purpose: new AssertionProofPurpose(),
+        documentLoader
+      });
+
+      expect(signedCredential).to.have.property('proof');
+      expect(signedCredential.proof.proofValue).to
+        .equal('zfMw453FJfB7c6Cx4Lo9dho8ePVnZrSwLeFAhUFPZXaS3pe1' +
+          'nS7v3PXFNkxvK515eNweAEiCbtceWGYQyLjtD2uB');
+    });
     it('should throw error if "signer" is not specified', async () => {
       const unsignedCredential = {...credential};
       const suite = new Ed25519Signature2020();

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -52,7 +52,7 @@ describe('Ed25519Signature2020', () => {
   });
 
   describe('sign() and verify()', () => {
-    it('should sign a document', async () => {
+    it('should sign a document with a key pair', async () => {
       const unsignedCredential = {...credential};
       const keyPair = await Ed25519VerificationKey2020.from({...mockKeyPair});
       const suite = new Ed25519Signature2020({key: keyPair});
@@ -69,11 +69,15 @@ describe('Ed25519Signature2020', () => {
         .equal('zfMw453FJfB7c6Cx4Lo9dho8ePVnZrSwLeFAhUFPZXaS3pe1' +
           'nS7v3PXFNkxvK515eNweAEiCbtceWGYQyLjtD2uB');
     });
+
     it('signs a document given a signer object', async () => {
       const unsignedCredential = {...credential};
       const keyPair = await Ed25519VerificationKey2020.from({...mockKeyPair});
+
+      // Note: Typically a signer object comes from a KMS; mocking it here
       const signer = keyPair.signer();
       signer.id = keyPair.id;
+
       const suite = new Ed25519Signature2020({signer});
       suite.date = '2010-01-01T19:23:24Z';
 
@@ -88,9 +92,11 @@ describe('Ed25519Signature2020', () => {
         .equal('zfMw453FJfB7c6Cx4Lo9dho8ePVnZrSwLeFAhUFPZXaS3pe1' +
           'nS7v3PXFNkxvK515eNweAEiCbtceWGYQyLjtD2uB');
     });
+
     it('should throw error if "signer" is not specified', async () => {
       const unsignedCredential = {...credential};
       let signedCredential;
+      // No key, no signer object given
       const suite = new Ed25519Signature2020();
       let err;
       try {
@@ -135,6 +141,7 @@ describe('Ed25519Signature2020', () => {
 
       expect(result.verified).to.be.true;
     });
+
     it('should fail verification if "proofValue" is not string',
       async () => {
         const suite = new Ed25519Signature2020();
@@ -156,6 +163,7 @@ describe('Ed25519Signature2020', () => {
           'The proof does not include a valid "proofValue" property.'
         );
       });
+
     it('should fail verification if "proofValue" is not given',
       async () => {
         const suite = new Ed25519Signature2020();
@@ -178,6 +186,7 @@ describe('Ed25519Signature2020', () => {
           'The proof does not include a valid "proofValue" property.'
         );
       });
+
     it('should fail verification if proofValue string does not start with "z"',
       async () => {
         const suite = new Ed25519Signature2020();
@@ -200,6 +209,7 @@ describe('Ed25519Signature2020', () => {
           'Only base58btc multibase encoding is supported.'
         );
       });
+
     it('should fail verification if proof type is not Ed25519Signature2020',
       async () => {
         const suite = new Ed25519Signature2020();

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -69,12 +69,12 @@ describe('Ed25519Signature2020', () => {
         .equal('zfMw453FJfB7c6Cx4Lo9dho8ePVnZrSwLeFAhUFPZXaS3pe1' +
           'nS7v3PXFNkxvK515eNweAEiCbtceWGYQyLjtD2uB');
     });
-    it('signs a document given a signer and verificationMethod', async () => {
+    it('signs a document given a signer object', async () => {
       const unsignedCredential = {...credential};
       const keyPair = await Ed25519VerificationKey2020.from({...mockKeyPair});
       const signer = keyPair.signer();
-      const verificationMethod = keyPair.id;
-      const suite = new Ed25519Signature2020({signer, verificationMethod});
+      signer.id = keyPair.id;
+      const suite = new Ed25519Signature2020({signer});
       suite.date = '2010-01-01T19:23:24Z';
 
       const signedCredential = await jsigs.sign(unsignedCredential, {
@@ -90,10 +90,10 @@ describe('Ed25519Signature2020', () => {
     });
     it('should throw error if "signer" is not specified', async () => {
       const unsignedCredential = {...credential};
-      const suite = new Ed25519Signature2020();
       let signedCredential;
       let err;
       try {
+        const suite = new Ed25519Signature2020();
         signedCredential = await jsigs.sign(unsignedCredential, {
           suite,
           purpose: new AssertionProofPurpose(),
@@ -104,7 +104,8 @@ describe('Ed25519Signature2020', () => {
       }
       expect(signedCredential).to.equal(undefined);
       expect(err.name).to.equal('Error');
-      expect(err.message).to.equal('A signer API has not been specified.');
+      expect(err.message).to
+        .equal('A signer API has not been specified.');
     });
   });
 


### PR DESCRIPTION
depends on: https://github.com/digitalbazaar/jsonld-signatures/pull/137

This test fails against `jsonld-signatures@8.0.2`.