### PR TITLE
Export suiteContext.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @digitalbazaar/ed25519-signature-2020 Changelog
 
+## 2.1.0 -
+
+### Added
+- Export the suite's context (and related objects such as context url,
+  documentLoader, etc), and also set them as a property of the suite class.
+- Set the `contextUrl` property on suite instance, to support context
+  enforcement during the `sign()` operation that was added to `jsonld-signatures`
+  `v9.1.0`.
+
 ## 2.0.1 - 2021-04-09
 
 ### Changed

--- a/lib/Ed25519Signature2020.js
+++ b/lib/Ed25519Signature2020.js
@@ -34,9 +34,6 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
    *
    * Advanced optional parameters and overrides:
    *
-   * @param {boolean} [options.addSuiteContext=true] - Toggles the default
-   *   behavior of each signature suite enforcing the presence of its own
-   *   `@context` (if it is not present, it's added to the context list).
    * @param {object} [options.proof] - A JSON-LD document with options to use
    *   for the `proof` node (e.g. any other custom fields can be provided here
    *   using a context different from security-v2).
@@ -45,13 +42,12 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
    *   canonize algorithm.
    */
   constructor({
-    key, signer, verifier, proof, date, useNativeCanonize,
-    addSuiteContext = true
+    key, signer, verifier, proof, date, useNativeCanonize
   } = {}) {
     super({
       type: 'Ed25519Signature2020', LDKeyClass: Ed25519VerificationKey2020,
       contextUrl: SUITE_CONTEXT_URL,
-      key, signer, verifier, proof, date, useNativeCanonize, addSuiteContext
+      key, signer, verifier, proof, date, useNativeCanonize
     });
     this.requiredKeyType = 'Ed25519VerificationKey2020';
   }

--- a/lib/Ed25519Signature2020.js
+++ b/lib/Ed25519Signature2020.js
@@ -34,6 +34,9 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
    *
    * Advanced optional parameters and overrides:
    *
+   * @param {boolean} [options.addSuiteContext=true] - Toggles the default
+   *   behavior of each signature suite enforcing the presence of its own
+   *   `@context` (if it is not present, it's added to the context list).
    * @param {object} [options.proof] - A JSON-LD document with options to use
    *   for the `proof` node (e.g. any other custom fields can be provided here
    *   using a context different from security-v2).
@@ -42,11 +45,13 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
    *   canonize algorithm.
    */
   constructor({
-    key, signer, verifier, proof, date, useNativeCanonize
+    key, signer, verifier, proof, date, useNativeCanonize,
+    addSuiteContext = true
   } = {}) {
     super({
       type: 'Ed25519Signature2020', LDKeyClass: Ed25519VerificationKey2020,
-      key, signer, verifier, proof, date, useNativeCanonize
+      contextUrl: SUITE_CONTEXT_URL,
+      key, signer, verifier, proof, date, useNativeCanonize, addSuiteContext
     });
     this.requiredKeyType = 'Ed25519VerificationKey2020';
   }
@@ -56,7 +61,6 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
    * LinkedDataSignature.createProof().
    *
    * @param {object} options - The options to use.
-   * @param {object} options.document - The original document to be signed.
    * @param {Uint8Array} options.verifyData - Data to be signed (extracted
    *   from document, according to the suite's spec).
    * @param {object} options.proof - Proof object (containing the proofPurpose,
@@ -65,17 +69,9 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
    * @returns {Promise<object>} Resolves with the proof containing the signature
    *   value.
    */
-  async sign({document, verifyData, proof}) {
+  async sign({verifyData, proof}) {
     if(!(this.signer && typeof this.signer.sign === 'function')) {
       throw new Error('A signer API has not been specified.');
-    }
-
-    const contexts = [].concat(document['@context'] || []);
-    if(!contexts.includes(SUITE_CONTEXT_URL)) {
-      throw new TypeError(
-        `The document to be signed must contain this suite's @context, ` +
-          `"${SUITE_CONTEXT_URL}".`
-      );
     }
 
     const signatureBytes = await this.signer.sign({data: verifyData});
@@ -115,13 +111,13 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
   }
 
   async assertVerificationMethod({verificationMethod}) {
-    const hasContext = verificationMethod['@context'] === SUITE_CONTEXT_URL ||
-      Array.isArray(verificationMethod['@context']) &&
-        verificationMethod['@context'].includes(SUITE_CONTEXT_URL);
-
-    if(!hasContext) {
+    if(!_includesContext({
+      document: verificationMethod, contextUrl: SUITE_CONTEXT_URL
+    })) {
+      // For DID Documents, since keys do not have their own contexts,
+      // the suite context is usually provided by the documentLoader logic
       throw new TypeError(
-        `The document to be signed must contain "${SUITE_CONTEXT_URL}".`
+        `The verification method (key) must contain "${SUITE_CONTEXT_URL}".`
       );
     }
 
@@ -138,6 +134,9 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
 
   async getVerificationMethod({proof, documentLoader}) {
     if(this.key) {
+      // This happens most often during sign() operations. For verify(),
+      // the expectation is that the verification method will be fetched
+      // by the documentLoader (below), not provided as a `key` parameter.
       return this.key.export({publicKey: true});
     }
 
@@ -161,8 +160,7 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
   }
 
   async matchProof({proof, document, purpose, documentLoader, expansionMap}) {
-    const contexts = [].concat(document['@context'] || []);
-    if(!contexts.includes(SUITE_CONTEXT_URL)) {
+    if(!_includesContext({document, contextUrl: SUITE_CONTEXT_URL})) {
       return false;
     }
 
@@ -183,6 +181,22 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
     }
     return verificationMethod === this.key.id;
   }
+}
+
+/**
+ * Tests whether a provided JSON-LD document includes a context url in its
+ * `@context` property.
+ *
+ * @param {object} options - Options hashmap.
+ * @param {object} options.document - A JSON-LD document.
+ * @param {string} options.contextUrl - A context url.
+ *
+ * @returns {boolean} Returns true if document includes context.
+ */
+function _includesContext({document, contextUrl}) {
+  const context = document['@context'];
+  return context === contextUrl ||
+    (Array.isArray(context) && context.includes(contextUrl));
 }
 
 Ed25519Signature2020.CONTEXT_URL = SUITE_CONTEXT_URL;

--- a/lib/Ed25519Signature2020.js
+++ b/lib/Ed25519Signature2020.js
@@ -9,7 +9,9 @@ import {
   Ed25519VerificationKey2020
 } from '@digitalbazaar/ed25519-verification-key-2020';
 
-const SUITE_CONTEXT = 'https://w3id.org/security/suites/ed25519-2020/v1';
+import suiteContext from 'ed25519-signature-2020-context';
+// 'https://w3id.org/security/suites/ed25519-2020/v1'
+const SUITE_CONTEXT_URL = suiteContext.constants.CONTEXT_URL;
 
 export class Ed25519Signature2020 extends LinkedDataSignature {
   /**
@@ -69,10 +71,10 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
     }
 
     const contexts = [].concat(document['@context'] || []);
-    if(!contexts.includes(SUITE_CONTEXT)) {
+    if(!contexts.includes(SUITE_CONTEXT_URL)) {
       throw new TypeError(
-        // eslint-disable-next-line max-len
-        `The document to be signed must contain this suite's @context, "${SUITE_CONTEXT}".`
+        `The document to be signed must contain this suite's @context, ` +
+          `"${SUITE_CONTEXT_URL}".`
       );
     }
 
@@ -113,13 +115,13 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
   }
 
   async assertVerificationMethod({verificationMethod}) {
-    const hasContext = verificationMethod['@context'] === SUITE_CONTEXT ||
+    const hasContext = verificationMethod['@context'] === SUITE_CONTEXT_URL ||
       Array.isArray(verificationMethod['@context']) &&
-        verificationMethod['@context'].includes(SUITE_CONTEXT);
+        verificationMethod['@context'].includes(SUITE_CONTEXT_URL);
 
     if(!hasContext) {
       throw new TypeError(
-        `The document to be signed must contain "${SUITE_CONTEXT}".`
+        `The document to be signed must contain "${SUITE_CONTEXT_URL}".`
       );
     }
 
@@ -160,7 +162,7 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
 
   async matchProof({proof, document, purpose, documentLoader, expansionMap}) {
     const contexts = [].concat(document['@context'] || []);
-    if(!contexts.includes(SUITE_CONTEXT)) {
+    if(!contexts.includes(SUITE_CONTEXT_URL)) {
       return false;
     }
 
@@ -182,3 +184,6 @@ export class Ed25519Signature2020 extends LinkedDataSignature {
     return verificationMethod === this.key.id;
   }
 }
+
+Ed25519Signature2020.CONTEXT_URL = SUITE_CONTEXT_URL;
+Ed25519Signature2020.CONTEXT = suiteContext.contexts.get(SUITE_CONTEXT_URL);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,7 @@
 /*!
  * Copyright (c) 2020-2021 Digital Bazaar, Inc. All rights reserved.
  */
+import suiteContext from 'ed25519-signature-2020-context';
+
 export {Ed25519Signature2020} from './Ed25519Signature2020.js';
+export {suiteContext};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ed25519-signature-2020-context": "^1.0.1",
     "esm": "^3.2.25",
     "jsonld": "^5.0.0",
-    "jsonld-signatures": "^9.0.0"
+    "jsonld-signatures": "digitalbazaar/jsonld-signatures#enforce-context"
   },
   "devDependencies": {
     "@transmute/jsonld-document-loader": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@digitalbazaar/ed25519-verification-key-2020": "^2.1.1",
     "base58-universal": "^1.0.0",
+    "ed25519-signature-2020-context": "^1.0.1",
     "esm": "^3.2.25",
     "jsonld": "^5.0.0",
     "jsonld-signatures": "^9.0.0"
@@ -25,7 +26,6 @@
     "chai": "^4.2.0",
     "cross-env": "^7.0.3",
     "did-context": "^3.0.0",
-    "ed25519-signature-2020-context": "^1.0.0",
     "eslint": "^7.20.0",
     "eslint-config-digitalbazaar": "^2.6.1",
     "eslint-plugin-jsdoc": "^32.2.0",
@@ -52,7 +52,7 @@
   "scripts": {
     "test": "npm run lint && npm run test-node && npm run test-karma",
     "test-karma": "karma start karma.conf.js",
-    "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} test/*.spec.js",
+    "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} --require test/test-mocha.js test/*.spec.js",
     "coverage": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text-summary npm run test-node",
     "coverage-ci": "cross-env NODE_ENV=test nyc --reporter=lcovonly npm run test-node",
     "coverage-report": "nyc report",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "base58-universal": "^1.0.0",
     "ed25519-signature-2020-context": "^1.0.1",
     "esm": "^3.2.25",
-    "jsonld": "^5.0.0",
-    "jsonld-signatures": "digitalbazaar/jsonld-signatures#enforce-context"
+    "jsonld": "^5.2.0",
+    "jsonld-signatures": "^9.0.1"
   },
   "devDependencies": {
     "@transmute/jsonld-document-loader": "^0.2.0",

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -53,7 +53,7 @@ describe('Ed25519Signature2020', () => {
         'contexts',
         'documentLoader',
       ]);
-      Ed25519Signature2020.CONTEXT_URL.should.exist;
+      should.exist(Ed25519Signature2020.CONTEXT_URL);
       Ed25519Signature2020.CONTEXT_URL.should
         .equal(suiteContext.constants.CONTEXT_URL);
       const context = Ed25519Signature2020.CONTEXT;

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -1,16 +1,14 @@
 /*!
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
-import chai from 'chai';
-chai.should();
-const {expect} = chai;
+import {expect} from 'chai';
 
 import jsigs from 'jsonld-signatures';
 const {purposes: {AssertionProofPurpose}} = jsigs;
 
 import {Ed25519VerificationKey2020} from
   '@digitalbazaar/ed25519-verification-key-2020';
-import {Ed25519Signature2020} from '../';
+import {Ed25519Signature2020, suiteContext} from '..';
 import {
   credential, mockKeyPair, mockPublicKey, controllerDoc
 } from './mock-data.js';
@@ -45,9 +43,16 @@ describe('Ed25519Signature2020', () => {
       .buildDocumentLoader();
   });
 
-  describe('constructor', () => {
-    it('should exist', async () => {
-      Ed25519Signature2020.should.exist;
+  describe('exports', () => {
+    it('it should have proper exports', async () => {
+      should.exist(Ed25519Signature2020);
+      should.exist(suiteContext);
+      suiteContext.should.have.keys([
+        'appContextMap',
+        'constants',
+        'contexts',
+        'documentLoader',
+      ]);
     });
   });
 

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -53,6 +53,12 @@ describe('Ed25519Signature2020', () => {
         'contexts',
         'documentLoader',
       ]);
+      Ed25519Signature2020.CONTEXT_URL.should.exist;
+      Ed25519Signature2020.CONTEXT_URL.should
+        .equal(suiteContext.constants.CONTEXT_URL);
+      const context = Ed25519Signature2020.CONTEXT;
+      context.should.exist;
+      context['@context'].id.should.equal('@id');
     });
   });
 

--- a/test/test-mocha.js
+++ b/test/test-mocha.js
@@ -1,5 +1,5 @@
 /*!
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
-const chai = require('chai');
+import chai from 'chai';
 global.should = chai.should();


### PR DESCRIPTION
It is currently the case that if one would like to sign something using `ed25519-signature-2020` they must add the suite context to the document. And the proposal is that one must ALSO provide a documentLoader to find said context. 

This module does not currently export the context URL or the context.  Which requires one to locate the context module to get the URL and the context and/or documentLoader implementation.

If suites package up the context like this, I think it opens the door to moving some of these context/documentLoader related gyrations into `jsonld-signatures`.  Perhaps the context related stuff would need to hang off `Ed25519Signature2020` somehow.

Would it not be possible for `jsonld-signatures` to add suite contexts as necessary and also pull in the context itself from the suite?

@dlongley @dmitrizagidulin 