### PR TITLE
Use jsigs 9.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ed25519-signature-2020-context": "^1.0.1",
     "ed25519-signature-2018-context": "^1.1.0",
     "esm": "^3.2.25",
-    "jsonld-signatures": "^9.0.1"
+    "jsonld-signatures": "^9.2.0"
   },
   "devDependencies": {
     "@digitalbazaar/ed25519-verification-key-2018": "^3.1.1",

--- a/test/Ed25519VerificationKey2020.spec.js
+++ b/test/Ed25519VerificationKey2020.spec.js
@@ -284,10 +284,7 @@ describe('Ed25519Signature2020', () => {
         const {errors} = result.error;
 
         expect(result.verified).to.be.false;
-        expect(errors[0].name).to.equal('Error');
-        expect(errors[0].message).to.equal(
-          'Could not verify any proofs; no proofs matched the required ' +
-            'suite and purpose.');
+        expect(errors[0].name).to.equal('NotFoundError');
       });
   });
   describe('verify() 2018 key type', () => {


### PR DESCRIPTION
This is really just a fix to the test suite that was relying on error message text instead of an error name. It will pass tests once jsigs 9.2.x is released.