### PR TITLE
fix undefined suiteContext2020 object when importing with jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @digitalbazaar/ed25519-signature-2020 Changelog
 
+## 3.0.1 - 2022-05-18
+- fix export of suiteContext which yielded an undefined value
+in jest consumers
+
 ## 3.0.0 - 2021-06-19
 
 ### Fixed

--- a/lib/Ed25519Signature2020.js
+++ b/lib/Ed25519Signature2020.js
@@ -17,6 +17,10 @@ const SUITE_CONTEXT_URL_2018 = suiteContext2018.constants.CONTEXT_URL;
 // multibase base58-btc header
 const MULTIBASE_BASE58BTC_HEADER = 'z';
 
+export {
+  suiteContext2020 as suiteContext
+};
+
 export class Ed25519Signature2020 extends LinkedDataSignature {
   /**
    * @param {object} options - Options hashmap.

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,4 @@
 /*!
  * Copyright (c) 2020-2021 Digital Bazaar, Inc. All rights reserved.
  */
-import suiteContext from 'ed25519-signature-2020-context';
-
-export {Ed25519Signature2020} from './Ed25519Signature2020.js';
-export {suiteContext};
+export {Ed25519Signature2020, suiteContext} from './Ed25519Signature2020.js';


### PR DESCRIPTION
When consuming with jest test runner, I was getting the following error:

```
/Users/julien/work/cert-verifier-js/node_modules/@digitalbazaar/ed25519-signature-2020/lib/Ed25519Signature2020.js:1
    TypeError: Cannot read properties of undefined (reading 'constants')

      at Object.<anonymous> (node_modules/@digitalbazaar/ed25519-signature-2020/lib/Ed25519Signature2020.js:14:44)
          at Object.<anonymous> (/Users/julien/work/cert-verifier-js/node_modules/@digitalbazaar/ed25519-signature-2020/lib/main.js:1)
```

coming from this line:
```
const SUITE_CONTEXT_URL = suiteContext2020.constants.CONTEXT_URL;
```

There was strangely no issue with the 2018 one. I noticed that `ed25519-signature-2020-context` was being called twice, the first time the value was undefined, the second it was the correct value. 

I am not sure what exactly was happening, but this seems to fix it without changing the API of the package.