### PR TITLE
Fix Ed25519Signature2020 spec url to working one in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For use with https://github.com/digitalbazaar/jsonld-signatures v9.0 and above.
 
 See also related specs:
 
-* [Ed25519Signature2020 Crypto Suite](https://w3c-ccg.github.io/lds-ed25519-2020/)
+* [Ed25519Signature2020 Crypto Suite](https://w3c.github.io/vc-di-eddsa/)
 
 ## Security
 


### PR DESCRIPTION
Addresses #28 This looks like the latest spec. let me know if it is not and if we want to link the editor's draft here instead.